### PR TITLE
Deploy RHDH 1.9 with scorecard plugin

### DIFF
--- a/config/dynamic-plugins.yaml
+++ b/config/dynamic-plugins.yaml
@@ -3,4 +3,27 @@ includes:
 plugins:
   - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-keycloak-dynamic
     disabled: false
+  - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend:bs_1.45.3__2.3.5!red-hat-developer-hub-backstage-plugin-scorecard-backend'
+    disabled: false
+  - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-github:bs_1.45.3__2.3.5!red-hat-developer-hub-backstage-plugin-scorecard-backend-module-github'
+    disabled: false
+  - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard:bs_1.45.3__2.3.5!red-hat-developer-hub-backstage-plugin-scorecard'
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          red-hat-developer-hub.backstage-plugin-scorecard:
+            entityTabs:
+              - path: '/scorecard'
+                title: Scorecard
+                mountPoint: entity.page.scorecard
+            mountPoints:
+              - mountPoint: entity.page.scorecard/cards
+                importName: EntityScorecardContent
+                config:
+                  layout:
+                    gridColumn: 1 / -1
+                if:
+                  allOf:
+                    - isKind: component
   


### PR DESCRIPTION
## Summary
- Enable scorecard plugin (backend + GitHub data source module + frontend)
- GitHub open PRs metrics with thresholds: Success (<5), Warning (5-15), Error (>15)
- Scorecard tab added to component entity pages

## Test plan
- [ ] Deploy with `/test deploy helm 1.9`
- [ ] Verify scorecard tab appears on component entity pages
- [ ] Verify GitHub open PRs metric is collected

🤖 Generated with [Claude Code](https://claude.com/claude-code)